### PR TITLE
added test and fix for not splicing passed array on get set

### DIFF
--- a/lib/method/shared.js
+++ b/lib/method/shared.js
@@ -69,7 +69,7 @@ function getPath (obj, path, length, filter, set, stamp) {
     }
   }
   if (set !== void 0) {
-    return createPath(obj, path.splice(i), length - i, set, stamp)
+    return createPath(obj, path.slice(i), length - i, set, stamp)
   }
 }
 

--- a/test/get.js
+++ b/test/get.js
@@ -57,3 +57,12 @@ test('get - root', (t) => {
   t.equal(base.a.b.c.get('root.c.compute'), 'haha', 'get base.a.b.c.$root')
   t.end()
 })
+
+test('get - array', (t) => {
+  const arr = ['a', 'b', 'c']
+  const base = new Base()
+  base.get(arr, true)
+  t.equal(base.a.b.c.compute(), true, 'set a.b.c: true')
+  t.same(arr, ['a', 'b', 'c'], 'array is unchanged')
+  t.end()
+})


### PR DESCRIPTION
using set in .get(x, set) would splice x, not allowing for reuse of x.